### PR TITLE
Generate/upload the private and public report calling the katoomba modul...

### DIFF
--- a/PublicServiceUploader.py
+++ b/PublicServiceUploader.py
@@ -7,7 +7,7 @@ confluenceSpaceKey = 'doc'
 confluenceParentTitle = 'Supported Services'
 updateServicePages = True # setting to False will only update index page
 
-if __name__ == '__main__':
+def upload():
     confluence = Confluence.Server(confluenceHost, confluenceUser, confluencePass)
     pageNameMap = {
         # Any services that are not in BiodiversityCatalogue can be placed here.
@@ -65,3 +65,6 @@ if __name__ == '__main__':
     # Confluence detects if this page is identical to the previous version, and
     # does not create a new revision.
     confluence.publish(content, confluenceSpaceKey, confluenceParentTitle, confluence.getPageId(confluenceSpaceKey, 'BioVeL Wiki'))
+
+if __name__ == '__main__':
+    upload()

--- a/ServiceUploader.py
+++ b/ServiceUploader.py
@@ -6,12 +6,15 @@ from config import confluenceHost, confluenceUser, confluencePass, serviceCatalo
 confluenceSpaceKey = 'BioVeL'
 confluenceParentTitle = 'Automatic Service Summary'
 
-if __name__ == '__main__':
+def upload():
     confluence = Confluence.Server(confluenceHost, confluenceUser, confluencePass)
     bdc = ServiceCatalographer.ServiceCatalographer(serviceCatalographerURL)
     services = bdc.getServices()
     for service in services:
+        serviceId = service.self.split('/')[-1]
         content = ServiceReporter.report(service)
         print(content)
-        serviceId = service.self.split('/')[-1]
         confluence.publish(content, confluenceSpaceKey, 'Service %s (%s) Evaluation' % (serviceId, service.name), confluence.getPageId(confluenceSpaceKey, confluenceParentTitle))
+
+if __name__ == '__main__':
+    upload()

--- a/katoomba.py
+++ b/katoomba.py
@@ -1,14 +1,4 @@
-import config
-from ServiceCatalographer import ServiceCatalographer
-from ServiceReporter import report
-from ServiceUploader import publish, getPageId
+import ServiceUploader, PublicServiceUploader
 
-parentId = getPageId(config.confluenceSpaceKey, config.confluenceParentTitle)
-
-catalog = ServiceCatalographer(config.serviceCatalographerUrl)
-
-for service in catalog.getServices():
-    content = report(service)
-    serviceId = service.self.split('/')[-1]
-    pageTitle = 'Service %s (%s) Evaluation' % (serviceId, service.name)
-    publish(content, config.confluenceSpaceKey, pageTitle, parentId)
+ServiceUploader.upload()
+PublicServiceUploader.upload()


### PR DESCRIPTION
...e

Extract the main functionality found the ServiceUploader and
PublicServiceUploader into functions so such functionally can be called
when we import those module from the katoomba module.

Modify the katoomba module to call the functions in ServiceUploader and
in PublicServiceUploader, so both the private and public report of all
the services are created and upload to confluence
